### PR TITLE
Added count (and percent) columns to dt from plotting functions.

### DIFF
--- a/R/percentage_regions.R
+++ b/R/percentage_regions.R
@@ -62,9 +62,9 @@ region_psite <- function(data, annotation, sample = NULL, transcripts = NULL,
   
   for(sam in sample) {
     frame_dt <- data[[sam]][as.character(transcript) %in% c_transcript
-                            ][, list(percentage = .N), by = list(region = psite_region)
+                            ][, list(count = .N), by = list(region = psite_region)
                               ][, sample := sam
-                                ][, percentage := (percentage / sum(percentage)) * 100]
+                                ][, percentage := (count / sum(count)) * 100]
     
     if (exists("melt_table")) {
       melt_table <- rbind(melt_table, frame_dt)
@@ -84,6 +84,7 @@ region_psite <- function(data, annotation, sample = NULL, transcripts = NULL,
   
   RNA_table <- data.table(region = c("5utr", "cds", "3utr"),
                           percentage = RNA_reg_perc,
+                          count = RNA_reg,
                           sample = rep("RNAs", 3),
                           class = "rna")
   

--- a/R/read_length_plot.R
+++ b/R/read_length_plot.R
@@ -33,21 +33,21 @@ rlength_distr <- function(data, sample, transcripts = NULL, cl = 100) {
   } else {
     dt <- data[[sample]][transcript %in% transcripts]
   }
-  
+
   xmin <- quantile(dt$length, (1 - cl/100)/2)
   xmax <- quantile(dt$length, 1 - (1 - cl/100)/2)
-  
+
   setkey(dt, length)
   dist <- dt[CJ(unique(dt$length)), list(count = .N), by = .EACHI
-             ][, count := (count / sum(count)) * 100]
+             ][, percentage := (count / sum(count)) * 100]
 
-  p <- ggplot(dist, aes(as.numeric(length), count)) +
+  p <- ggplot(dist, aes(as.numeric(length), percentage)) +
     geom_bar(stat = "identity", fill = "gray80") +
     labs(title = sample, x = "Read length", y = "Count (%)") +
     theme_bw(base_size = 18) +
     theme(plot.title = element_text(hjust = 0.5)) +
     scale_x_continuous(limits = c(xmin - 0.5, xmax + 0.5), breaks = seq(xmin + ((xmin) %% 2), xmax, by = max(c(1, floor((xmax - xmin)/7)))))
-  
+
   output <- list()
   output[["plot"]] <- p
   output[["dt"]] <- dist


### PR DESCRIPTION
Hi Fabio,
For downstream analysis, I needed read counts, not percentages, that are used for plotting in `rlength_distr()` and `region_psite()`. For this purpose I modified these functions to include both `count` and `percentage` in `dt` objects.
This is a subtle modification but might be helpful to someone who needs count values. I would appreciate it if you could consider merging this. 
Thanks, 
Sotta